### PR TITLE
Replace manual Ollama setup instructions with one-click setup scripts

### DIFF
--- a/cyberneuro_multi-agent-neuroimaging-analysis/App.tsx
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/App.tsx
@@ -1675,16 +1675,17 @@ const App: React.FC = () => {
         </div>
       </div>
 
-      {availableModels.length > 0 && (
-        <div className="flex flex-col gap-2 text-xs">
+      <div className="flex flex-col gap-2 text-xs">
           <div className="flex gap-2">
           <div className="flex flex-col gap-1 w-1/3">
             <label className="text-slate-500">General Model</label>
             <select 
-              value={selectedGeneralModel} 
+              value={availableModels.length > 0 ? selectedGeneralModel : ''} 
               onChange={handleGeneralModelChange}
-              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-300 focus:outline-none focus:border-indigo-500"
+              disabled={availableModels.length === 0}
+              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-300 focus:outline-none focus:border-indigo-500 disabled:opacity-50"
             >
+              {availableModels.length === 0 && <option value="">No models</option>}
               {availableModels.map(m => (
                 <option key={m} value={m}>{m}</option>
               ))}
@@ -1693,10 +1694,12 @@ const App: React.FC = () => {
           <div className="flex flex-col gap-1 w-1/3">
             <label className="text-slate-500">Neuro Model</label>
             <select 
-              value={selectedNeuroModel} 
+              value={availableModels.length > 0 ? selectedNeuroModel : ''} 
               onChange={handleNeuroModelChange}
-              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-300 focus:outline-none focus:border-indigo-500"
+              disabled={availableModels.length === 0}
+              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-300 focus:outline-none focus:border-indigo-500 disabled:opacity-50"
             >
+              {availableModels.length === 0 && <option value="">No models</option>}
               {availableModels.map(m => (
                 <option key={m} value={m}>{m}</option>
               ))}
@@ -1707,10 +1710,12 @@ const App: React.FC = () => {
               <Pencil className="w-3 h-3" /> Visualizer
             </label>
             <select 
-              value={visualizerModel} 
+              value={availableModels.length > 0 ? visualizerModel : ''} 
               onChange={(e) => setVisualizerModel(e.target.value)}
-              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-300 focus:outline-none focus:border-cyan-500"
+              disabled={availableModels.length === 0}
+              className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-slate-300 focus:outline-none focus:border-cyan-500 disabled:opacity-50"
             >
+              {availableModels.length === 0 && <option value="">No models</option>}
               {availableModels.map(m => (
                 <option key={m} value={m}>{m}</option>
               ))}
@@ -1753,7 +1758,6 @@ const App: React.FC = () => {
                 </label>
           </div>
         </div>
-      )}
 
       
       {selectedVisualizationId && (
@@ -1853,6 +1857,8 @@ const App: React.FC = () => {
           onMultiFileUpload={handleFileUpload}
           onMergeDatasets={handleManualMerge}
           onSyncDataset={handleManualSync}
+          disableSend={availableModels.length === 0}
+          disableSendHint="No models available — connect Ollama first"
           history={history}
         />
       </div>

--- a/cyberneuro_multi-agent-neuroimaging-analysis/App.tsx
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/App.tsx
@@ -33,7 +33,7 @@ import { chartDataToCode, prepareDataScope } from './utils/chartToCode';
 import ChatArea from './components/Chat/ChatArea';
 import VisualizerArea from './components/Visualizer/VisualizerArea';
 import ResizablePanels from './components/ResizablePanels';
-import { X, Pencil, Database } from 'lucide-react';
+import { X, Pencil, Database, Download } from 'lucide-react';
 import { getMockVisualization, getAllMockVisualizations } from './mockVisualizations';
 import { useWorkflow } from './hooks/useWorkflow';
 
@@ -1875,32 +1875,35 @@ const App: React.FC = () => {
         </button>
       </div>
 
-      <div className="space-y-2 text-[11px] leading-relaxed">
-        <p>
-          <span className="font-semibold">1) Install Ollama</span>: 
-          <a
-            href="https://ollama.com/download"
-            target="_blank"
-            rel="noreferrer"
-            className="ml-1 underline text-amber-200 hover:text-amber-100"
-          >
-            https://ollama.com/download
-          </a>
-        </p>
-        <p><span className="font-semibold">2) Pull a free cloud model</span>: <span className="font-mono">ollama pull gpt-oss:20b-cloud</span></p>
-        <div>
-          <p className="font-semibold">3) Configure CORS and restart Ollama</p>
-          <p className="mt-1 text-amber-300/90">Linux (systemd):</p>
-          <p className="font-mono">sudo systemctl edit ollama</p>
-          <p className="font-mono">[Service]</p>
-          <p className="font-mono">Environment="OLLAMA_HOST=0.0.0.0:11434"</p>
-          <p className="font-mono">Environment="OLLAMA_ORIGINS={pageOrigin}"</p>
-          <p className="font-mono">sudo systemctl daemon-reload && sudo systemctl restart ollama</p>
-          <p className="mt-1 text-amber-300/90">Windows (PowerShell):</p>
-          <p className="font-mono">[Environment]::SetEnvironmentVariable("OLLAMA_HOST","0.0.0.0:11434","User")</p>
-          <p className="font-mono">[Environment]::SetEnvironmentVariable("OLLAMA_ORIGINS","{pageOrigin}","User")</p>
-          <p>Then quit and reopen Ollama app.</p>
-        </div>
+      <p className="mb-3 text-[11px] text-amber-300/90">
+        Download and run the setup script for your OS. It will install Ollama,
+        configure CORS, and pull the default model automatically.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <a
+          href={`${import.meta.env.BASE_URL}scripts/setup_ollama.bat`}
+          download
+          className="inline-flex items-center gap-1.5 rounded-md bg-amber-700/60 px-3 py-1.5 text-xs font-medium text-amber-100 hover:bg-amber-600/70 transition-colors"
+        >
+          <Download className="h-3.5 w-3.5" />
+          Windows
+        </a>
+        <a
+          href={`${import.meta.env.BASE_URL}scripts/setup_ollama_macos.sh`}
+          download
+          className="inline-flex items-center gap-1.5 rounded-md bg-amber-700/60 px-3 py-1.5 text-xs font-medium text-amber-100 hover:bg-amber-600/70 transition-colors"
+        >
+          <Download className="h-3.5 w-3.5" />
+          macOS
+        </a>
+        <a
+          href={`${import.meta.env.BASE_URL}scripts/setup_ollama_linux.sh`}
+          download
+          className="inline-flex items-center gap-1.5 rounded-md bg-amber-700/60 px-3 py-1.5 text-xs font-medium text-amber-100 hover:bg-amber-600/70 transition-colors"
+        >
+          <Download className="h-3.5 w-3.5" />
+          Linux
+        </a>
       </div>
     </div>
   ) : null;

--- a/cyberneuro_multi-agent-neuroimaging-analysis/components/Chat/ChatArea.tsx
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/components/Chat/ChatArea.tsx
@@ -94,6 +94,8 @@ interface ChatAreaProps {
   onImageRemove: (uploadedAt: number, e: React.MouseEvent) => void;
   onMergeDatasets: () => void;
   onSyncDataset: () => void;
+  disableSend?: boolean;
+  disableSendHint?: string;
   // NEW: workflow history
   history: WorkflowHistory;
 }
@@ -103,6 +105,7 @@ const ChatArea: React.FC<ChatAreaProps> = React.memo(({
   placeholder,
   datasets, activeDatasetIds, onDatasetToggle, onDatasetRemove, onMultiFileUpload, onImageUpload,
   uploadedImages, activeImageId, onImageToggle, onImageRemove, onMergeDatasets, onSyncDataset,
+  disableSend = false, disableSendHint,
   history,
 }) => {
   const [input, setInput] = useState('');
@@ -228,7 +231,7 @@ const ChatArea: React.FC<ChatAreaProps> = React.memo(({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (input.trim() && !isProcessing) {
+    if (input.trim() && !isProcessing && !disableSend) {
       onSendMessage(input);
       setInput('');
     }
@@ -459,8 +462,8 @@ const ChatArea: React.FC<ChatAreaProps> = React.memo(({
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            disabled={isProcessing}
-            placeholder={inputPlaceholder}
+            disabled={isProcessing || disableSend}
+            placeholder={disableSend ? (disableSendHint || 'No models available — connect Ollama first') : inputPlaceholder}
             className="flex-1 bg-slate-800 text-slate-200 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 border border-slate-700 disabled:opacity-50 placeholder-slate-500"
           />
           <button
@@ -474,7 +477,7 @@ const ChatArea: React.FC<ChatAreaProps> = React.memo(({
           </button>
           <button
             type="submit"
-            disabled={!input.trim() || isProcessing}
+            disabled={!input.trim() || isProcessing || disableSend}
             className="p-2.5 bg-indigo-600 hover:bg-indigo-500 text-white rounded-md disabled:opacity-50 disabled:hover:bg-indigo-600 transition-colors"
           >
             <Send className="w-4 h-4" />

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama.bat
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama.bat
@@ -1,0 +1,70 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+echo ============================================================
+echo   Ollama Auto-Setup Script for Windows
+echo ============================================================
+echo.
+
+:: Step 1 - Install Ollama automatically via the official installer
+echo [Step 1/3] Installing Ollama...
+
+where ollama >nul 2>&1
+if !ERRORLEVEL! equ 0 (
+    echo   Ollama is already installed, skipping download.
+    goto :step2
+)
+
+echo   Downloading and installing via official installer...
+echo.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://ollama.com/install.ps1 | iex"
+
+:: Refresh PATH so the current session can find the newly installed binary.
+:: The installer writes to the User PATH, which this shell has not reloaded.
+for /f "tokens=2,*" %%A in ('reg query "HKCU\Environment" /v Path 2^>nul') do (
+    set "PATH=%%B;!PATH!"
+)
+
+where ollama >nul 2>&1
+if !ERRORLEVEL! neq 0 (
+    echo.
+    echo   ERROR: Could not find ollama after installation.
+    echo   Please install manually from https://ollama.com/download
+    goto :end
+)
+echo.
+echo   Ollama installed successfully.
+
+:step2
+:: Step 2 - Set environment variables for the current user
+echo.
+echo [Step 2/3] Configuring environment variables...
+
+powershell -NoProfile -Command ^
+  "[Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','User');"^
+  "[Environment]::SetEnvironmentVariable('OLLAMA_ORIGINS','https://acmlab.github.io','User');"
+
+echo   OLLAMA_HOST    = 0.0.0.0:11434
+echo   OLLAMA_ORIGINS = https://acmlab.github.io
+echo   (User-level environment variables have been written.)
+echo.
+echo   Please quit and reopen the Ollama desktop app so it picks
+echo   up the new variables, then press any key to continue...
+pause >nul
+
+:: Step 3 - Pull the default model
+echo.
+echo [Step 3/3] Pulling model gpt-oss:20b-cloud (this may take a while)...
+ollama pull gpt-oss:20b-cloud
+
+if !ERRORLEVEL! neq 0 (
+    echo   WARNING: Model pull failed. Make sure Ollama is running and try again.
+)
+
+:end
+echo.
+echo ============================================================
+echo   Setup complete!  You can now return to the web app.
+echo ============================================================
+pause
+endlocal

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama.bat
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama.bat
@@ -6,21 +6,21 @@ echo   Ollama Auto-Setup Script for Windows
 echo ============================================================
 echo.
 
-:: Step 1 - Install Ollama automatically via the official installer
-echo [Step 1/3] Installing Ollama...
+:: ---- Step 1 - Install Ollama --------------------------------
+echo [Step 1/4] Installing Ollama...
 
 where ollama >nul 2>&1
 if !ERRORLEVEL! equ 0 (
-    echo   Ollama is already installed, skipping download.
+    echo   Ollama is already installed, skipping.
     goto :step2
 )
 
-echo   Downloading and installing via official installer...
+echo   Downloading and installing (the install phase may appear
+echo   idle for up to a minute — this is normal, please wait)...
 echo.
 powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://ollama.com/install.ps1 | iex"
 
-:: Refresh PATH so the current session can find the newly installed binary.
-:: The installer writes to the User PATH, which this shell has not reloaded.
+:: Refresh PATH so the current session sees the new binary
 for /f "tokens=2,*" %%A in ('reg query "HKCU\Environment" /v Path 2^>nul') do (
     set "PATH=%%B;!PATH!"
 )
@@ -36,25 +36,56 @@ echo.
 echo   Ollama installed successfully.
 
 :step2
-:: Step 2 - Set environment variables for the current user
+:: ---- Step 2 - Configure environment variables ---------------
 echo.
-echo [Step 2/3] Configuring environment variables...
+echo [Step 2/4] Configuring environment variables...
 
+:: Persist to User-level registry
 powershell -NoProfile -Command ^
   "[Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','User');"^
   "[Environment]::SetEnvironmentVariable('OLLAMA_ORIGINS','https://acmlab.github.io','User');"
 
+:: Also set for the current session so ollama serve picks them up
+set "OLLAMA_HOST=0.0.0.0:11434"
+set "OLLAMA_ORIGINS=https://acmlab.github.io"
+
 echo   OLLAMA_HOST    = 0.0.0.0:11434
 echo   OLLAMA_ORIGINS = https://acmlab.github.io
-echo   (User-level environment variables have been written.)
-echo.
-echo   Please quit and reopen the Ollama desktop app so it picks
-echo   up the new variables, then press any key to continue...
-pause >nul
 
-:: Step 3 - Pull the default model
+:: ---- Step 3 - Restart Ollama --------------------------------
 echo.
-echo [Step 3/3] Pulling model gpt-oss:20b-cloud (this may take a while)...
+echo [Step 3/4] Restarting Ollama with new configuration...
+
+taskkill /f /im "Ollama.exe" >nul 2>&1
+taskkill /f /im "ollama app.exe" >nul 2>&1
+taskkill /f /im "ollama_llama_server.exe" >nul 2>&1
+timeout /t 2 /nobreak >nul
+
+:: Start ollama serve in a hidden window
+powershell -NoProfile -Command "Start-Process ollama -ArgumentList 'serve' -WindowStyle Hidden"
+echo   Waiting for Ollama to become ready...
+
+:: Poll until ollama responds (max 30 seconds)
+set RETRIES=0
+:wait_loop
+if !RETRIES! geq 15 (
+    echo   WARNING: Ollama did not respond within 30 seconds.
+    echo   Attempting model pull anyway...
+    goto :step4
+)
+timeout /t 2 /nobreak >nul
+ollama list >nul 2>&1
+if !ERRORLEVEL! equ 0 (
+    echo   Ollama is ready.
+    goto :step4
+)
+set /a RETRIES+=1
+goto :wait_loop
+
+:step4
+:: ---- Step 4 - Pull the default model ------------------------
+echo.
+echo [Step 4/4] Pulling model gpt-oss:20b-cloud (this may take a while)...
 ollama pull gpt-oss:20b-cloud
 
 if !ERRORLEVEL! neq 0 (
@@ -65,6 +96,7 @@ if !ERRORLEVEL! neq 0 (
 echo.
 echo ============================================================
 echo   Setup complete!  You can now return to the web app.
+echo   This window will close in 10 seconds.
 echo ============================================================
-pause
+timeout /t 10 /nobreak >nul
 endlocal

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_linux.sh
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_linux.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "============================================================"
+echo "  Ollama Auto-Setup Script for Linux"
+echo "============================================================"
+echo
+
+# -----------------------------------------------------------
+# Step 1 - Install Ollama via the official installer
+# -----------------------------------------------------------
+echo "[Step 1/3] Installing Ollama..."
+
+if command -v ollama &>/dev/null; then
+    echo "  Ollama is already installed: $(ollama --version 2>/dev/null || echo 'unknown version')"
+else
+    curl -fsSL https://ollama.com/install.sh | sh
+    echo "  Ollama installed successfully."
+fi
+
+echo
+
+# -----------------------------------------------------------
+# Step 2 - Configure CORS via systemd override
+# -----------------------------------------------------------
+echo "[Step 2/3] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
+
+OVERRIDE_DIR="/etc/systemd/system/ollama.service.d"
+OVERRIDE_FILE="${OVERRIDE_DIR}/environment.conf"
+
+if [ -d /run/systemd/system ]; then
+    sudo mkdir -p "${OVERRIDE_DIR}"
+
+    sudo tee "${OVERRIDE_FILE}" >/dev/null <<'EOF'
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0:11434"
+Environment="OLLAMA_ORIGINS=https://acmlab.github.io"
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl restart ollama
+    echo "  systemd override written to ${OVERRIDE_FILE}"
+    echo "  Ollama service restarted."
+else
+    echo "  systemd not detected."
+    echo "  Please add the following to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+    echo ""
+    echo "    export OLLAMA_HOST=\"0.0.0.0:11434\""
+    echo "    export OLLAMA_ORIGINS=\"https://acmlab.github.io\""
+    echo ""
+    echo "  Then restart your terminal and re-launch Ollama."
+fi
+
+echo
+
+# -----------------------------------------------------------
+# Step 3 - Pull the default model
+# -----------------------------------------------------------
+echo "[Step 3/3] Pulling model gpt-oss:20b-cloud (this may take a while)..."
+ollama pull gpt-oss:20b-cloud || echo "  WARNING: Model pull failed. Make sure Ollama is running and try again."
+
+echo
+echo "============================================================"
+echo "  Setup complete!  You can now return to the web app."
+echo "============================================================"

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_linux.sh
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_linux.sh
@@ -7,9 +7,9 @@ echo "============================================================"
 echo
 
 # -----------------------------------------------------------
-# Step 1 - Install Ollama via the official installer
+# Step 1 - Install Ollama
 # -----------------------------------------------------------
-echo "[Step 1/3] Installing Ollama..."
+echo "[Step 1/4] Installing Ollama..."
 
 if command -v ollama &>/dev/null; then
     echo "  Ollama is already installed: $(ollama --version 2>/dev/null || echo 'unknown version')"
@@ -23,7 +23,7 @@ echo
 # -----------------------------------------------------------
 # Step 2 - Configure CORS via systemd override
 # -----------------------------------------------------------
-echo "[Step 2/3] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
+echo "[Step 2/4] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
 
 OVERRIDE_DIR="/etc/systemd/system/ollama.service.d"
 OVERRIDE_FILE="${OVERRIDE_DIR}/environment.conf"
@@ -37,26 +37,52 @@ Environment="OLLAMA_HOST=0.0.0.0:11434"
 Environment="OLLAMA_ORIGINS=https://acmlab.github.io"
 EOF
 
-    sudo systemctl daemon-reload
-    sudo systemctl restart ollama
     echo "  systemd override written to ${OVERRIDE_FILE}"
-    echo "  Ollama service restarted."
 else
-    echo "  systemd not detected."
-    echo "  Please add the following to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
-    echo ""
-    echo "    export OLLAMA_HOST=\"0.0.0.0:11434\""
-    echo "    export OLLAMA_ORIGINS=\"https://acmlab.github.io\""
-    echo ""
-    echo "  Then restart your terminal and re-launch Ollama."
+    echo "  systemd not detected — writing to ~/.bashrc instead."
+    grep -q 'OLLAMA_HOST' "$HOME/.bashrc" 2>/dev/null || {
+        printf '\n# Ollama configuration\nexport OLLAMA_HOST="0.0.0.0:11434"\nexport OLLAMA_ORIGINS="https://acmlab.github.io"\n' >> "$HOME/.bashrc"
+    }
 fi
+
+export OLLAMA_HOST="0.0.0.0:11434"
+export OLLAMA_ORIGINS="https://acmlab.github.io"
 
 echo
 
 # -----------------------------------------------------------
-# Step 3 - Pull the default model
+# Step 3 - Restart Ollama
 # -----------------------------------------------------------
-echo "[Step 3/3] Pulling model gpt-oss:20b-cloud (this may take a while)..."
+echo "[Step 3/4] Restarting Ollama with new configuration..."
+
+if [ -d /run/systemd/system ]; then
+    sudo systemctl daemon-reload
+    sudo systemctl restart ollama
+    echo "  Ollama service restarted via systemd."
+else
+    pkill -x ollama 2>/dev/null || true
+    sleep 1
+    nohup ollama serve &>/dev/null &
+    echo "  Ollama restarted in background."
+fi
+
+echo "  Waiting for Ollama to become ready..."
+RETRIES=0
+while [ "$RETRIES" -lt 15 ]; do
+    if ollama list &>/dev/null; then
+        echo "  Ollama is ready."
+        break
+    fi
+    sleep 2
+    RETRIES=$((RETRIES + 1))
+done
+
+echo
+
+# -----------------------------------------------------------
+# Step 4 - Pull the default model
+# -----------------------------------------------------------
+echo "[Step 4/4] Pulling model gpt-oss:20b-cloud (this may take a while)..."
 ollama pull gpt-oss:20b-cloud || echo "  WARNING: Model pull failed. Make sure Ollama is running and try again."
 
 echo

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_macos.sh
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_macos.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "============================================================"
+echo "  Ollama Auto-Setup Script for macOS"
+echo "============================================================"
+echo
+
+# -----------------------------------------------------------
+# Step 1 - Install Ollama via the official installer
+# -----------------------------------------------------------
+echo "[Step 1/3] Installing Ollama..."
+
+if command -v ollama &>/dev/null; then
+    echo "  Ollama is already installed: $(ollama --version 2>/dev/null || echo 'unknown version')"
+else
+    curl -fsSL https://ollama.com/install.sh | sh
+    echo "  Ollama installed successfully."
+fi
+
+echo
+
+# -----------------------------------------------------------
+# Step 2 - Configure CORS environment variables
+# -----------------------------------------------------------
+echo "[Step 2/3] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
+
+OLLAMA_HOST_VAL="0.0.0.0:11434"
+OLLAMA_ORIGINS_VAL="https://acmlab.github.io"
+
+launchctl setenv OLLAMA_HOST "${OLLAMA_HOST_VAL}" 2>/dev/null || true
+launchctl setenv OLLAMA_ORIGINS "${OLLAMA_ORIGINS_VAL}" 2>/dev/null || true
+
+SHELL_RC=""
+if [ -f "$HOME/.zshrc" ]; then
+    SHELL_RC="$HOME/.zshrc"
+elif [ -f "$HOME/.bashrc" ]; then
+    SHELL_RC="$HOME/.bashrc"
+elif [ -f "$HOME/.bash_profile" ]; then
+    SHELL_RC="$HOME/.bash_profile"
+fi
+
+if [ -n "${SHELL_RC}" ]; then
+    grep -q 'OLLAMA_HOST' "${SHELL_RC}" 2>/dev/null || {
+        printf '\n# Ollama configuration\nexport OLLAMA_HOST="%s"\nexport OLLAMA_ORIGINS="%s"\n' \
+            "${OLLAMA_HOST_VAL}" "${OLLAMA_ORIGINS_VAL}" >> "${SHELL_RC}"
+        echo "  Environment variables appended to ${SHELL_RC}"
+    }
+else
+    echo "  No shell profile found. Please add manually to your profile:"
+    echo "    export OLLAMA_HOST=\"${OLLAMA_HOST_VAL}\""
+    echo "    export OLLAMA_ORIGINS=\"${OLLAMA_ORIGINS_VAL}\""
+fi
+
+echo "  launchctl environment set for current session."
+echo ""
+echo "  If Ollama is already running, please quit and reopen it."
+
+echo
+
+# -----------------------------------------------------------
+# Step 3 - Pull the default model
+# -----------------------------------------------------------
+echo "[Step 3/3] Pulling model gpt-oss:20b-cloud (this may take a while)..."
+ollama pull gpt-oss:20b-cloud || echo "  WARNING: Model pull failed. Make sure Ollama is running and try again."
+
+echo
+echo "============================================================"
+echo "  Setup complete!  You can now return to the web app."
+echo "============================================================"

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_macos.sh
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_macos.sh
@@ -7,9 +7,9 @@ echo "============================================================"
 echo
 
 # -----------------------------------------------------------
-# Step 1 - Install Ollama via the official installer
+# Step 1 - Install Ollama
 # -----------------------------------------------------------
-echo "[Step 1/3] Installing Ollama..."
+echo "[Step 1/4] Installing Ollama..."
 
 if command -v ollama &>/dev/null; then
     echo "  Ollama is already installed: $(ollama --version 2>/dev/null || echo 'unknown version')"
@@ -23,7 +23,7 @@ echo
 # -----------------------------------------------------------
 # Step 2 - Configure CORS environment variables
 # -----------------------------------------------------------
-echo "[Step 2/3] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
+echo "[Step 2/4] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
 
 OLLAMA_HOST_VAL="0.0.0.0:11434"
 OLLAMA_ORIGINS_VAL="https://acmlab.github.io"
@@ -47,21 +47,50 @@ if [ -n "${SHELL_RC}" ]; then
         echo "  Environment variables appended to ${SHELL_RC}"
     }
 else
-    echo "  No shell profile found. Please add manually to your profile:"
-    echo "    export OLLAMA_HOST=\"${OLLAMA_HOST_VAL}\""
-    echo "    export OLLAMA_ORIGINS=\"${OLLAMA_ORIGINS_VAL}\""
+    echo "  No shell profile found — creating ~/.zshrc"
+    printf '# Ollama configuration\nexport OLLAMA_HOST="%s"\nexport OLLAMA_ORIGINS="%s"\n' \
+        "${OLLAMA_HOST_VAL}" "${OLLAMA_ORIGINS_VAL}" > "$HOME/.zshrc"
 fi
 
-echo "  launchctl environment set for current session."
-echo ""
-echo "  If Ollama is already running, please quit and reopen it."
+export OLLAMA_HOST="${OLLAMA_HOST_VAL}"
+export OLLAMA_ORIGINS="${OLLAMA_ORIGINS_VAL}"
 
 echo
 
 # -----------------------------------------------------------
-# Step 3 - Pull the default model
+# Step 3 - Restart Ollama
 # -----------------------------------------------------------
-echo "[Step 3/3] Pulling model gpt-oss:20b-cloud (this may take a while)..."
+echo "[Step 3/4] Restarting Ollama with new configuration..."
+
+pkill -x "Ollama" 2>/dev/null || true
+pkill -x "ollama" 2>/dev/null || true
+sleep 1
+
+if [ -d "/Applications/Ollama.app" ]; then
+    open -a Ollama
+    echo "  Ollama.app relaunched."
+else
+    nohup ollama serve &>/dev/null &
+    echo "  ollama serve started in background."
+fi
+
+echo "  Waiting for Ollama to become ready..."
+RETRIES=0
+while [ "$RETRIES" -lt 15 ]; do
+    if ollama list &>/dev/null; then
+        echo "  Ollama is ready."
+        break
+    fi
+    sleep 2
+    RETRIES=$((RETRIES + 1))
+done
+
+echo
+
+# -----------------------------------------------------------
+# Step 4 - Pull the default model
+# -----------------------------------------------------------
+echo "[Step 4/4] Pulling model gpt-oss:20b-cloud (this may take a while)..."
 ollama pull gpt-oss:20b-cloud || echo "  WARNING: Model pull failed. Make sure Ollama is running and try again."
 
 echo

--- a/cyberneuro_multi-agent-neuroimaging-analysis/services/ollamaService.ts
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/services/ollamaService.ts
@@ -4,7 +4,7 @@ import { McpTool, ChatMessage, AgentType } from "../types";
 import { PROMPTS } from "../constants";
 import { validatePlanColumns } from './internalTools';
 
-const DEFAULT_OLLAMA_HOST = 'http://127.0.0.1:11434';
+const DEFAULT_OLLAMA_HOST = 'http://localhost:11434';
 const OLLAMA_HOST_STORAGE_KEY = 'neuroagent.ollamaHost';
 
 const normalizeHttpUrl = (value: string) => value.trim().replace(/\/$/, '');

--- a/cyberneuro_multi-agent-neuroimaging-analysis/vite-env.d.ts
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Add per-platform auto-setup scripts (Windows .bat, Linux .sh, macOS .sh) that install Ollama, configure CORS env vars, and pull the default model. Replace the verbose text instructions in the Ollama toast with three download buttons.