### PR TITLE
Add ollama login step and make scripts double-clickable

### DIFF
--- a/cyberneuro_multi-agent-neuroimaging-analysis/App.tsx
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/App.tsx
@@ -1883,21 +1883,23 @@ const App: React.FC = () => {
 
       <p className="mb-3 text-[11px] text-amber-300/90">
         Download and run the setup script for your OS. It will install Ollama,
-        configure CORS, and pull the default model automatically.
+        configure CORS, log in, and pull the default model automatically.
       </p>
       <div className="flex flex-wrap gap-2">
         <a
           href={`${import.meta.env.BASE_URL}scripts/setup_ollama.bat`}
           download
           className="inline-flex items-center gap-1.5 rounded-md bg-amber-700/60 px-3 py-1.5 text-xs font-medium text-amber-100 hover:bg-amber-600/70 transition-colors"
+          title="Double-click the downloaded .bat file to run"
         >
           <Download className="h-3.5 w-3.5" />
           Windows
         </a>
         <a
-          href={`${import.meta.env.BASE_URL}scripts/setup_ollama_macos.sh`}
+          href={`${import.meta.env.BASE_URL}scripts/setup_ollama_macos.command`}
           download
           className="inline-flex items-center gap-1.5 rounded-md bg-amber-700/60 px-3 py-1.5 text-xs font-medium text-amber-100 hover:bg-amber-600/70 transition-colors"
+          title="Right-click → Open the downloaded .command file to run"
         >
           <Download className="h-3.5 w-3.5" />
           macOS
@@ -1906,11 +1908,15 @@ const App: React.FC = () => {
           href={`${import.meta.env.BASE_URL}scripts/setup_ollama_linux.sh`}
           download
           className="inline-flex items-center gap-1.5 rounded-md bg-amber-700/60 px-3 py-1.5 text-xs font-medium text-amber-100 hover:bg-amber-600/70 transition-colors"
+          title="Run: chmod +x setup_ollama_linux.sh && ./setup_ollama_linux.sh"
         >
           <Download className="h-3.5 w-3.5" />
           Linux
         </a>
       </div>
+      <p className="mt-2 text-[10px] text-amber-400/70">
+        macOS: right-click the file → Open. Linux: run <span className="font-mono">chmod +x</span> first, then double-click.
+      </p>
     </div>
   ) : null;
 

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama.bat
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama.bat
@@ -7,7 +7,7 @@ echo ============================================================
 echo.
 
 :: ---- Step 1 - Install Ollama --------------------------------
-echo [Step 1/4] Installing Ollama...
+echo [Step 1/5] Installing Ollama...
 
 where ollama >nul 2>&1
 if !ERRORLEVEL! equ 0 (
@@ -38,7 +38,7 @@ echo   Ollama installed successfully.
 :step2
 :: ---- Step 2 - Configure environment variables ---------------
 echo.
-echo [Step 2/4] Configuring environment variables...
+echo [Step 2/5] Configuring environment variables...
 
 :: Persist to User-level registry
 powershell -NoProfile -Command ^
@@ -54,7 +54,7 @@ echo   OLLAMA_ORIGINS = https://acmlab.github.io
 
 :: ---- Step 3 - Restart Ollama --------------------------------
 echo.
-echo [Step 3/4] Restarting Ollama with new configuration...
+echo [Step 3/5] Restarting Ollama with new configuration...
 
 taskkill /f /im "Ollama.exe" >nul 2>&1
 taskkill /f /im "ollama app.exe" >nul 2>&1
@@ -70,7 +70,7 @@ set RETRIES=0
 :wait_loop
 if !RETRIES! geq 15 (
     echo   WARNING: Ollama did not respond within 30 seconds.
-    echo   Attempting model pull anyway...
+    echo   Attempting login anyway...
     goto :step4
 )
 timeout /t 2 /nobreak >nul
@@ -83,9 +83,21 @@ set /a RETRIES+=1
 goto :wait_loop
 
 :step4
-:: ---- Step 4 - Pull the default model ------------------------
+:: ---- Step 4 - Login to Ollama -------------------------------
 echo.
-echo [Step 4/4] Pulling model gpt-oss:20b-cloud (this may take a while)...
+echo [Step 4/5] Logging in to Ollama...
+echo   (If prompted, enter your Ollama credentials.)
+echo.
+ollama login
+
+if !ERRORLEVEL! neq 0 (
+    echo   WARNING: Login failed or was skipped. Model pull may fail
+    echo   if the model requires authentication.
+)
+
+:: ---- Step 5 - Pull the default model ------------------------
+echo.
+echo [Step 5/5] Pulling model gpt-oss:20b-cloud (this may take a while)...
 ollama pull gpt-oss:20b-cloud
 
 if !ERRORLEVEL! neq 0 (

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_linux.sh
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_linux.sh
@@ -9,7 +9,7 @@ echo
 # -----------------------------------------------------------
 # Step 1 - Install Ollama
 # -----------------------------------------------------------
-echo "[Step 1/4] Installing Ollama..."
+echo "[Step 1/5] Installing Ollama..."
 
 if command -v ollama &>/dev/null; then
     echo "  Ollama is already installed: $(ollama --version 2>/dev/null || echo 'unknown version')"
@@ -23,7 +23,7 @@ echo
 # -----------------------------------------------------------
 # Step 2 - Configure CORS via systemd override
 # -----------------------------------------------------------
-echo "[Step 2/4] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
+echo "[Step 2/5] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
 
 OVERRIDE_DIR="/etc/systemd/system/ollama.service.d"
 OVERRIDE_FILE="${OVERRIDE_DIR}/environment.conf"
@@ -53,7 +53,7 @@ echo
 # -----------------------------------------------------------
 # Step 3 - Restart Ollama
 # -----------------------------------------------------------
-echo "[Step 3/4] Restarting Ollama with new configuration..."
+echo "[Step 3/5] Restarting Ollama with new configuration..."
 
 if [ -d /run/systemd/system ]; then
     sudo systemctl daemon-reload
@@ -80,9 +80,19 @@ done
 echo
 
 # -----------------------------------------------------------
-# Step 4 - Pull the default model
+# Step 4 - Login to Ollama
 # -----------------------------------------------------------
-echo "[Step 4/4] Pulling model gpt-oss:20b-cloud (this may take a while)..."
+echo "[Step 4/5] Logging in to Ollama..."
+echo "  (If prompted, enter your Ollama credentials.)"
+echo
+ollama login || echo "  WARNING: Login failed or was skipped."
+
+echo
+
+# -----------------------------------------------------------
+# Step 5 - Pull the default model
+# -----------------------------------------------------------
+echo "[Step 5/5] Pulling model gpt-oss:20b-cloud (this may take a while)..."
 ollama pull gpt-oss:20b-cloud || echo "  WARNING: Model pull failed. Make sure Ollama is running and try again."
 
 echo

--- a/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_macos.command
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/public/scripts/setup_ollama_macos.command
@@ -9,7 +9,7 @@ echo
 # -----------------------------------------------------------
 # Step 1 - Install Ollama
 # -----------------------------------------------------------
-echo "[Step 1/4] Installing Ollama..."
+echo "[Step 1/5] Installing Ollama..."
 
 if command -v ollama &>/dev/null; then
     echo "  Ollama is already installed: $(ollama --version 2>/dev/null || echo 'unknown version')"
@@ -23,7 +23,7 @@ echo
 # -----------------------------------------------------------
 # Step 2 - Configure CORS environment variables
 # -----------------------------------------------------------
-echo "[Step 2/4] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
+echo "[Step 2/5] Configuring OLLAMA_HOST and OLLAMA_ORIGINS..."
 
 OLLAMA_HOST_VAL="0.0.0.0:11434"
 OLLAMA_ORIGINS_VAL="https://acmlab.github.io"
@@ -60,7 +60,7 @@ echo
 # -----------------------------------------------------------
 # Step 3 - Restart Ollama
 # -----------------------------------------------------------
-echo "[Step 3/4] Restarting Ollama with new configuration..."
+echo "[Step 3/5] Restarting Ollama with new configuration..."
 
 pkill -x "Ollama" 2>/dev/null || true
 pkill -x "ollama" 2>/dev/null || true
@@ -88,9 +88,19 @@ done
 echo
 
 # -----------------------------------------------------------
-# Step 4 - Pull the default model
+# Step 4 - Login to Ollama
 # -----------------------------------------------------------
-echo "[Step 4/4] Pulling model gpt-oss:20b-cloud (this may take a while)..."
+echo "[Step 4/5] Logging in to Ollama..."
+echo "  (If prompted, enter your Ollama credentials.)"
+echo
+ollama login || echo "  WARNING: Login failed or was skipped."
+
+echo
+
+# -----------------------------------------------------------
+# Step 5 - Pull the default model
+# -----------------------------------------------------------
+echo "[Step 5/5] Pulling model gpt-oss:20b-cloud (this may take a while)..."
 ollama pull gpt-oss:20b-cloud || echo "  WARNING: Model pull failed. Make sure Ollama is running and try again."
 
 echo


### PR DESCRIPTION
Add 'ollama login' as Step 4 in all setup scripts so users can authenticate before pulling models. Rename macOS script from .sh to .command so it opens in Terminal.app on double-click. Add helper hints in the toast UI for macOS (right-click to Open) and Linux (chmod +x).