### PR TITLE
Add CIVET skill MVP

### DIFF
--- a/CIVET_SKILLS.md
+++ b/CIVET_SKILLS.md
@@ -1,0 +1,37 @@
+# CIVET Skill Endpoints
+
+Run the FastAPI server with your preferred ASGI runner, for example:
+
+```sh
+uvicorn mcp_server.server:app --reload
+```
+
+Inspect a CIVET subject folder:
+
+```sh
+curl -X POST http://127.0.0.1:8000/inspect_civet_folder \
+  -H 'Content-Type: application/json' \
+  -d '{"subject_dir": "/path/to/civet/subject"}'
+```
+
+Run QC checks:
+
+```sh
+curl -X POST http://127.0.0.1:8000/run_civet_qc_check \
+  -H 'Content-Type: application/json' \
+  -d '{"qc_file": "/path/to/qc.csv", "subject_id": "sub-001"}'
+```
+
+Summarize a cortical thickness map:
+
+```sh
+curl -X POST http://127.0.0.1:8000/load_cortical_thickness_map \
+  -H 'Content-Type: application/json' \
+  -d '{"thickness_file": "/path/to/thickness.txt"}'
+```
+
+The manual endpoint schema is available at:
+
+```sh
+curl http://127.0.0.1:8000/api/schema
+```

--- a/mcp_server/civet_skills.py
+++ b/mcp_server/civet_skills.py
@@ -1,0 +1,641 @@
+"""Utilities for turning CIVET outputs into agent-readable JSON."""
+
+from __future__ import annotations
+
+import csv
+import math
+import re
+from pathlib import Path
+from statistics import mean, pstdev
+from typing import Iterable
+
+
+QC_THRESHOLDS = {
+    "MASK_ERROR": 10.0,
+    "LEFT_INTER": 100.0,
+    "RIGHT_INTER": 100.0,
+    "SURFACE_INTERSECTIONS": 500.0,
+}
+
+FILE_GROUP_PATTERNS = {
+    "native_images": (
+        "native",
+        "nuc",
+        "t1",
+        "t2",
+    ),
+    "final_images": (
+        "final",
+        "stx",
+        "stereotaxic",
+        "tal",
+    ),
+    "masks": (
+        "mask",
+        "brainmask",
+        "brain_mask",
+        "skull",
+    ),
+    "classification_files": (
+        "classify",
+        "classified",
+        "classification",
+        "cls",
+        "tissue",
+    ),
+    "surfaces": (
+        "surface",
+        "surf",
+        "white",
+        "gray",
+        "grey",
+        "pial",
+        "mid",
+        "central",
+    ),
+    "thickness_files": (
+        "thick",
+        "thickness",
+        "tlink",
+    ),
+    "qc_tables": (
+        "qc",
+        "quality",
+    ),
+    "verify_images": (
+        "verify",
+        "verification",
+        "snapshot",
+        "montage",
+        "png",
+        "jpg",
+        "jpeg",
+    ),
+    "logs": (
+        "log",
+        "stderr",
+        "stdout",
+    ),
+}
+
+IMAGE_SUFFIXES = {".mnc", ".nii", ".gz", ".img", ".hdr", ".mgz"}
+TABLE_SUFFIXES = {".csv", ".tsv", ".txt", ".dat"}
+SURFACE_SUFFIXES = {".obj", ".surf", ".vtk", ".ply", ".gii", ".mesh"}
+VERIFY_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".tif", ".tiff"}
+LOG_SUFFIXES = {".log", ".out", ".err"}
+
+
+def inspect_civet_folder(subject_dir: str) -> dict:
+    """Inspect a CIVET subject folder and summarize known output groups."""
+
+    root = Path(subject_dir).expanduser()
+    if not root.exists():
+        return {
+            "status": "error",
+            "message": "Subject folder does not exist.",
+            "subject_dir": str(root),
+        }
+    if not root.is_dir():
+        return {
+            "status": "error",
+            "message": "Subject path is not a directory.",
+            "subject_dir": str(root),
+        }
+
+    groups: dict[str, list[str]] = {group: [] for group in FILE_GROUP_PATTERNS}
+    all_files = [path for path in root.rglob("*") if path.is_file()]
+
+    for path in all_files:
+        for group in _classify_civet_file(path):
+            groups[group].append(_safe_relative(path, root))
+
+    for paths in groups.values():
+        paths.sort()
+
+    warnings = [
+        f"No {group.replace('_', ' ')} found."
+        for group, paths in groups.items()
+        if not paths
+    ]
+
+    return {
+        "status": "warning" if warnings else "ok",
+        "subject_dir": str(root),
+        "n_files_scanned": len(all_files),
+        "groups": {
+            group: {"count": len(paths), "files": paths}
+            for group, paths in groups.items()
+        },
+        "warnings": warnings,
+    }
+
+
+def run_civet_qc_check(qc_file: str, subject_id: str | None = None) -> dict:
+    """Parse a CIVET QC table and flag common failure thresholds."""
+
+    path = Path(qc_file).expanduser()
+    if not path.exists():
+        return {
+            "status": "error",
+            "message": "QC file does not exist.",
+            "qc_file": str(path),
+        }
+    if not path.is_file():
+        return {
+            "status": "error",
+            "message": "QC path is not a file.",
+            "qc_file": str(path),
+        }
+
+    try:
+        rows = _parse_table(path)
+    except Exception as exc:  # pragma: no cover - kept defensive for tool use
+        return {
+            "status": "error",
+            "message": f"Could not parse QC file: {exc}",
+            "qc_file": str(path),
+        }
+
+    if not rows:
+        return {
+            "status": "error",
+            "message": "QC file contains no data rows.",
+            "qc_file": str(path),
+        }
+
+    selected_rows = _select_subject_rows(rows, subject_id)
+    if subject_id is not None and not selected_rows:
+        return {
+            "status": "error",
+            "message": f"Subject '{subject_id}' was not found in the QC file.",
+            "qc_file": str(path),
+            "subject_id": subject_id,
+            "n_rows": len(rows),
+        }
+
+    problems = []
+    warnings = []
+    for row_index, row in selected_rows:
+        row_label = _row_subject_id(row) or str(row_index)
+        for metric, threshold in QC_THRESHOLDS.items():
+            if metric not in row:
+                warnings.append(f"Missing QC metric {metric}.")
+                continue
+            value = _to_float(row.get(metric))
+            if value is None:
+                warnings.append(f"Metric {metric} is non-numeric for row {row_label}.")
+                continue
+            if value > threshold:
+                problems.append(
+                    {
+                        "row_index": row_index,
+                        "subject_id": _row_subject_id(row),
+                        "metric": metric,
+                        "value": value,
+                        "threshold": threshold,
+                        "message": f"{metric}={value:g} exceeds {threshold:g}.",
+                    }
+                )
+
+    unique_warnings = sorted(set(warnings))
+    status = "warning" if problems or unique_warnings else "ok"
+
+    return {
+        "status": status,
+        "qc_file": str(path),
+        "subject_id": subject_id,
+        "n_rows": len(rows),
+        "n_rows_checked": len(selected_rows),
+        "problems": problems,
+        "warnings": unique_warnings,
+    }
+
+
+def load_cortical_thickness_map(thickness_file: str) -> dict:
+    """Load a CIVET cortical thickness text file and summarize its values."""
+
+    path = Path(thickness_file).expanduser()
+    if not path.exists():
+        return {
+            "status": "error",
+            "message": "Thickness file does not exist.",
+            "thickness_file": str(path),
+        }
+    if not path.is_file():
+        return {
+            "status": "error",
+            "message": "Thickness path is not a file.",
+            "thickness_file": str(path),
+        }
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="latin-1")
+
+    values = []
+    skipped_tokens = []
+    for token in re.split(r"[\s,;]+", text.strip()):
+        if not token:
+            continue
+        value = _to_float(token)
+        if value is None or not math.isfinite(value):
+            skipped_tokens.append(token)
+            continue
+        values.append(value)
+
+    if not values:
+        return {
+            "status": "error",
+            "message": "Thickness file contains no numeric values.",
+            "thickness_file": str(path),
+            "n_skipped_tokens": len(skipped_tokens),
+            "skipped_tokens_preview": skipped_tokens[:10],
+        }
+
+    warnings = []
+    if skipped_tokens:
+        warnings.append(f"Skipped {len(skipped_tokens)} non-numeric token(s).")
+    if any(value < 0 for value in values):
+        warnings.append("Negative cortical thickness values found.")
+    if any(value > 10 for value in values):
+        warnings.append("Unusually large cortical thickness values found.")
+
+    return {
+        "status": "warning" if warnings else "ok",
+        "thickness_file": str(path),
+        "n_vertices": len(values),
+        "mean_thickness": mean(values),
+        "std_thickness": pstdev(values) if len(values) > 1 else 0.0,
+        "min_thickness": min(values),
+        "max_thickness": max(values),
+        "preview_values": values[:10],
+        "warnings": warnings,
+        "n_skipped_tokens": len(skipped_tokens),
+        "skipped_tokens_preview": skipped_tokens[:10],
+    }
+
+
+def visualize_civet_surface(
+    surface_path: str,
+    overlay_path: str | None = None,
+    output_dir: str = "outputs",
+) -> dict:
+    """Create an interactive Plotly HTML visualization for a CIVET surface."""
+
+    surface = Path(surface_path).expanduser()
+    if not surface.exists():
+        return {
+            "status": "error",
+            "message": "Surface file does not exist.",
+            "surface_path": str(surface),
+        }
+    if not surface.is_file():
+        return {
+            "status": "error",
+            "message": "Surface path is not a file.",
+            "surface_path": str(surface),
+        }
+
+    try:
+        vertices, faces, parse_warnings = _parse_obj_surface(surface)
+    except ValueError as exc:
+        return {
+            "status": "error",
+            "message": f"Could not parse surface file: {exc}",
+            "surface_path": str(surface),
+        }
+    except OSError as exc:
+        return {
+            "status": "error",
+            "message": f"Could not read surface file: {exc}",
+            "surface_path": str(surface),
+        }
+
+    warnings = list(parse_warnings)
+    overlay_values = None
+    overlay = Path(overlay_path).expanduser() if overlay_path else None
+    if overlay is not None:
+        overlay_result = _load_numeric_values(overlay, label="Overlay")
+        if overlay_result["status"] == "error":
+            return overlay_result
+        overlay_values = overlay_result["values"]
+        warnings.extend(overlay_result["warnings"])
+        if len(overlay_values) != len(vertices):
+            return {
+                "status": "error",
+                "message": (
+                    "Overlay length does not match surface vertex count: "
+                    f"{len(overlay_values)} values for {len(vertices)} vertices."
+                ),
+                "surface_path": str(surface),
+                "overlay_path": str(overlay),
+                "n_vertices": len(vertices),
+                "n_faces": len(faces),
+            }
+
+    try:
+        figure_path = _write_surface_plot(
+            surface=surface,
+            vertices=vertices,
+            faces=faces,
+            overlay_values=overlay_values,
+            output_dir=Path(output_dir).expanduser(),
+        )
+    except ImportError:
+        return {
+            "status": "error",
+            "message": "Plotly is required to generate CIVET surface visualizations.",
+            "surface_path": str(surface),
+        }
+    except Exception as exc:  # pragma: no cover - defensive for filesystem/plotly edges
+        return {
+            "status": "error",
+            "message": f"Could not generate Plotly figure: {exc}",
+            "surface_path": str(surface),
+        }
+
+    return {
+        "status": "warning" if warnings else "ok",
+        "figure_path": str(figure_path),
+        "surface_path": str(surface),
+        "overlay_path": str(overlay) if overlay else None,
+        "n_vertices": len(vertices),
+        "n_faces": len(faces),
+        "warnings": warnings,
+    }
+
+
+def _classify_civet_file(path: Path) -> set[str]:
+    groups = set()
+    lowered_name = path.name.lower()
+    lowered_full_path = str(path).lower()
+    suffixes = "".join(path.suffixes).lower()
+    suffix = path.suffix.lower()
+
+    if any(term in lowered_full_path for term in FILE_GROUP_PATTERNS["native_images"]):
+        if suffix in IMAGE_SUFFIXES or suffixes.endswith(".nii.gz"):
+            groups.add("native_images")
+    if any(term in lowered_full_path for term in FILE_GROUP_PATTERNS["final_images"]):
+        if suffix in IMAGE_SUFFIXES or suffixes.endswith(".nii.gz"):
+            groups.add("final_images")
+    if any(term in lowered_full_path for term in FILE_GROUP_PATTERNS["masks"]):
+        groups.add("masks")
+    if any(term in lowered_full_path for term in FILE_GROUP_PATTERNS["classification_files"]):
+        groups.add("classification_files")
+    if suffix in SURFACE_SUFFIXES or any(
+        term in lowered_full_path for term in FILE_GROUP_PATTERNS["surfaces"]
+    ):
+        groups.add("surfaces")
+    if any(term in lowered_full_path for term in FILE_GROUP_PATTERNS["thickness_files"]):
+        groups.add("thickness_files")
+    if (
+        suffix in TABLE_SUFFIXES
+        and any(term in lowered_full_path for term in FILE_GROUP_PATTERNS["qc_tables"])
+    ):
+        groups.add("qc_tables")
+    if suffix in VERIFY_SUFFIXES or any(
+        term in lowered_name for term in FILE_GROUP_PATTERNS["verify_images"]
+    ):
+        groups.add("verify_images")
+    if suffix in LOG_SUFFIXES or any(
+        term in lowered_name for term in FILE_GROUP_PATTERNS["logs"]
+    ):
+        groups.add("logs")
+
+    return groups
+
+
+def _parse_obj_surface(path: Path) -> tuple[list[tuple[float, float, float]], list[tuple[int, int, int]], list[str]]:
+    vertices = []
+    faces = []
+    warnings = []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        lines = path.read_text(encoding="latin-1").splitlines()
+
+    for line_number, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if parts[0] == "v":
+            if len(parts) < 4:
+                warnings.append(f"Skipped malformed vertex line {line_number}.")
+                continue
+            try:
+                vertices.append((float(parts[1]), float(parts[2]), float(parts[3])))
+            except ValueError:
+                warnings.append(f"Skipped non-numeric vertex line {line_number}.")
+        elif parts[0] == "f":
+            face_indices = []
+            for token in parts[1:]:
+                index_text = token.split("/", 1)[0]
+                try:
+                    index = int(index_text)
+                except ValueError:
+                    warnings.append(f"Skipped malformed face line {line_number}.")
+                    face_indices = []
+                    break
+                if index == 0:
+                    warnings.append(f"Skipped zero-indexed face line {line_number}.")
+                    face_indices = []
+                    break
+                face_indices.append(index - 1 if index > 0 else len(vertices) + index)
+            if len(face_indices) < 3:
+                continue
+            for triangle in _triangulate_face(face_indices):
+                if any(index < 0 or index >= len(vertices) for index in triangle):
+                    warnings.append(f"Skipped out-of-range face line {line_number}.")
+                    continue
+                faces.append(triangle)
+
+    if not vertices:
+        raise ValueError("no Wavefront OBJ vertex lines were found.")
+    if not faces:
+        raise ValueError("no Wavefront OBJ face lines were found.")
+
+    return vertices, faces, sorted(set(warnings))
+
+
+def _triangulate_face(indices: list[int]) -> list[tuple[int, int, int]]:
+    return [(indices[0], indices[i], indices[i + 1]) for i in range(1, len(indices) - 1)]
+
+
+def _load_numeric_values(path: Path, label: str) -> dict:
+    if not path.exists():
+        return {
+            "status": "error",
+            "message": f"{label} file does not exist.",
+            "overlay_path": str(path),
+        }
+    if not path.is_file():
+        return {
+            "status": "error",
+            "message": f"{label} path is not a file.",
+            "overlay_path": str(path),
+        }
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="latin-1")
+
+    values = []
+    skipped_tokens = []
+    for token in re.split(r"[\s,;]+", text.strip()):
+        if not token:
+            continue
+        value = _to_float(token)
+        if value is None or not math.isfinite(value):
+            skipped_tokens.append(token)
+            continue
+        values.append(value)
+
+    if not values:
+        return {
+            "status": "error",
+            "message": f"{label} file contains no numeric values.",
+            "overlay_path": str(path),
+        }
+
+    warnings = []
+    if skipped_tokens:
+        warnings.append(f"Skipped {len(skipped_tokens)} non-numeric overlay token(s).")
+
+    return {"status": "ok", "values": values, "warnings": warnings}
+
+
+def _write_surface_plot(
+    surface: Path,
+    vertices: list[tuple[float, float, float]],
+    faces: list[tuple[int, int, int]],
+    overlay_values: list[float] | None,
+    output_dir: Path,
+) -> Path:
+    import plotly.graph_objects as go
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    figure_path = output_dir / f"{surface.stem}_surface.html"
+    x, y, z = zip(*vertices, strict=True)
+    i, j, k = zip(*faces, strict=True)
+
+    mesh_kwargs = {
+        "x": list(x),
+        "y": list(y),
+        "z": list(z),
+        "i": list(i),
+        "j": list(j),
+        "k": list(k),
+        "opacity": 1.0,
+        "flatshading": False,
+        "name": surface.name,
+    }
+    if overlay_values is None:
+        mesh_kwargs.update(
+            {
+                "color": "lightsteelblue",
+                "lighting": {"ambient": 0.45, "diffuse": 0.8, "specular": 0.15},
+            }
+        )
+    else:
+        mesh_kwargs.update(
+            {
+                "intensity": overlay_values,
+                "colorscale": "Viridis",
+                "showscale": True,
+                "colorbar": {"title": "Overlay"},
+            }
+        )
+
+    fig = go.Figure(data=[go.Mesh3d(**mesh_kwargs)])
+    fig.update_layout(
+        title=f"CIVET surface: {surface.name}",
+        scene={
+            "aspectmode": "data",
+            "xaxis": {"title": "X"},
+            "yaxis": {"title": "Y"},
+            "zaxis": {"title": "Z"},
+        },
+        margin={"l": 0, "r": 0, "t": 48, "b": 0},
+    )
+    fig.write_html(str(figure_path), include_plotlyjs="cdn", full_html=True)
+    return figure_path
+
+
+def _parse_table(path: Path) -> list[dict[str, str]]:
+    text = path.read_text(encoding="utf-8-sig")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return []
+
+    delimiter = _detect_delimiter(lines[0])
+    if delimiter is None:
+        header = re.split(r"\s+", lines[0])
+        rows = []
+        for line in lines[1:]:
+            cells = re.split(r"\s+", line)
+            rows.append(_zip_row(header, cells))
+        return rows
+
+    reader = csv.DictReader(lines, delimiter=delimiter)
+    return [
+        {str(key).strip(): (value or "").strip() for key, value in row.items() if key}
+        for row in reader
+    ]
+
+
+def _detect_delimiter(header_line: str) -> str | None:
+    if "\t" in header_line:
+        return "\t"
+    if "," in header_line:
+        return ","
+    if ";" in header_line:
+        return ";"
+    return None
+
+
+def _zip_row(header: Iterable[str], cells: Iterable[str]) -> dict[str, str]:
+    return {
+        str(key).strip(): str(value).strip()
+        for key, value in zip(header, cells, strict=False)
+    }
+
+
+def _select_subject_rows(
+    rows: list[dict[str, str]], subject_id: str | None
+) -> list[tuple[int, dict[str, str]]]:
+    indexed_rows = list(enumerate(rows, start=1))
+    if subject_id is None:
+        return indexed_rows
+    return [
+        (index, row)
+        for index, row in indexed_rows
+        if _row_subject_id(row) == subject_id
+    ]
+
+
+def _row_subject_id(row: dict[str, str]) -> str | None:
+    for key in ("subject_id", "SUBJECT_ID", "subject", "SUBJECT", "id", "ID"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _to_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)

--- a/mcp_server/mcp_server.py
+++ b/mcp_server/mcp_server.py
@@ -52,6 +52,20 @@ from fastapi.middleware.cors import CORSMiddleware
 
 
 from stats_tools import StatsToolkit
+try:
+    from civet_skills import (
+        inspect_civet_folder,
+        load_cortical_thickness_map,
+        run_civet_qc_check,
+        visualize_civet_surface,
+    )
+except ImportError:
+    from mcp_server.civet_skills import (
+        inspect_civet_folder,
+        load_cortical_thickness_map,
+        run_civet_qc_check,
+        visualize_civet_surface,
+    )
 
 def _get_server_host_port() -> tuple[str, int]:
     host = os.getenv("MCP_HOST", "0.0.0.0").strip() or "0.0.0.0"
@@ -135,6 +149,21 @@ class InternetSearchRequest(BaseModel):
     max_results: int = Field(10, ge=1, le=50, description="Max results (1-50)")
     from_year: Optional[int] = Field(None, ge=1800, le=2100, description="Filter from publication year (inclusive)")
     to_year: Optional[int] = Field(None, ge=1800, le=2100, description="Filter to publication year (inclusive)")
+
+class InspectCivetFolderRequest(BaseModel):
+    subject_dir: str = Field(..., description="Path to a CIVET subject output folder")
+
+class RunCivetQcCheckRequest(BaseModel):
+    qc_file: str = Field(..., description="Path to a CIVET QC CSV, TSV, or whitespace table")
+    subject_id: Optional[str] = Field(None, description="Optional subject identifier to select one QC row")
+
+class LoadCorticalThicknessMapRequest(BaseModel):
+    thickness_file: str = Field(..., description="Path to a text file containing cortical thickness values")
+
+class VisualizeCivetSurfaceRequest(BaseModel):
+    surface_path: str = Field(..., description="Path to a CIVET OBJ surface file")
+    overlay_path: Optional[str] = Field(None, description="Optional path to vertex-wise overlay values")
+    output_dir: str = Field("outputs", description="Directory where the Plotly HTML figure will be written")
 
 # class OpenNeuroSearchRequest(BaseModel):
 #     query: str = Field(..., min_length=1, description="Keyword query for OpenNeuro datasets")
@@ -1964,6 +1993,26 @@ Returns: Combined x and y data for normative modeling""",
                 "description": "Search PubMed via NCBI E-utilities (esearch + esummary)",
                 "parameters": PubMedSearchRequest.model_json_schema(),
             },
+            "inspect_civet_folder": {
+                "method": "POST",
+                "description": "Inspect a CIVET subject folder for common output groups.",
+                "parameters": InspectCivetFolderRequest.model_json_schema(),
+            },
+            "run_civet_qc_check": {
+                "method": "POST",
+                "description": "Parse a CIVET QC table and flag common QC problems.",
+                "parameters": RunCivetQcCheckRequest.model_json_schema(),
+            },
+            "load_cortical_thickness_map": {
+                "method": "POST",
+                "description": "Summarize a CIVET cortical thickness text file.",
+                "parameters": LoadCorticalThicknessMapRequest.model_json_schema(),
+            },
+            "visualize_civet_surface": {
+                "method": "POST",
+                "description": "Generate an interactive Plotly HTML visualization for a CIVET OBJ surface.",
+                "parameters": VisualizeCivetSurfaceRequest.model_json_schema(),
+            },
             # "openalex_search": {
             #     "method": "POST",
             #     "description": "Scholarly discovery search via OpenAlex works",
@@ -2077,6 +2126,87 @@ async def delete_file(request: Request) -> JSONResponse:
     except Exception as e:
         logger.error(f"Delete file error: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Delete failed: {str(e)}")
+
+@server.custom_route("/inspect_civet_folder", methods=["POST"])
+@rate_limit
+async def http_inspect_civet_folder(request: Request) -> JSONResponse:
+    """HTTP endpoint for CIVET folder inspection."""
+    try:
+        data = await request.json()
+        validated_data = InspectCivetFolderRequest(**data)
+
+        result = inspect_civet_folder(subject_dir=validated_data.subject_dir)
+        return JSONResponse(result)
+    except ValueError as e:
+        logger.error(f"Validation error: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid parameters: {str(e)}")
+    except Exception as e:
+        logger.error(f"Request error: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@server.custom_route("/run_civet_qc_check", methods=["POST"])
+@rate_limit
+async def http_run_civet_qc_check(request: Request) -> JSONResponse:
+    """HTTP endpoint for CIVET QC checks."""
+    try:
+        data = await request.json()
+        validated_data = RunCivetQcCheckRequest(**data)
+
+        result = run_civet_qc_check(
+            qc_file=validated_data.qc_file,
+            subject_id=validated_data.subject_id,
+        )
+        return JSONResponse(result)
+    except ValueError as e:
+        logger.error(f"Validation error: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid parameters: {str(e)}")
+    except Exception as e:
+        logger.error(f"Request error: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@server.custom_route("/load_cortical_thickness_map", methods=["POST"])
+@rate_limit
+async def http_load_cortical_thickness_map(request: Request) -> JSONResponse:
+    """HTTP endpoint for CIVET cortical thickness summaries."""
+    try:
+        data = await request.json()
+        validated_data = LoadCorticalThicknessMapRequest(**data)
+
+        result = load_cortical_thickness_map(
+            thickness_file=validated_data.thickness_file,
+        )
+        return JSONResponse(result)
+    except ValueError as e:
+        logger.error(f"Validation error: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid parameters: {str(e)}")
+    except Exception as e:
+        logger.error(f"Request error: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@server.custom_route("/visualize_civet_surface", methods=["POST"])
+@rate_limit
+async def http_visualize_civet_surface(request: Request) -> JSONResponse:
+    """HTTP endpoint for CIVET surface visualization."""
+    try:
+        data = await request.json()
+        validated_data = VisualizeCivetSurfaceRequest(**data)
+
+        result = visualize_civet_surface(
+            surface_path=validated_data.surface_path,
+            overlay_path=validated_data.overlay_path,
+            output_dir=validated_data.output_dir,
+        )
+        return JSONResponse(result)
+    except ValueError as e:
+        logger.error(f"Validation error: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid parameters: {str(e)}")
+    except Exception as e:
+        logger.error(f"Request error: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
 
 @server.custom_route("/run_cfc_wavelet_analysis", methods=["POST"])
 @rate_limit

--- a/mcp_server/tests/test_civet_skills.py
+++ b/mcp_server/tests/test_civet_skills.py
@@ -1,0 +1,194 @@
+import math
+
+from mcp_server.civet_skills import (
+    inspect_civet_folder,
+    load_cortical_thickness_map,
+    run_civet_qc_check,
+    visualize_civet_surface,
+)
+
+
+def test_valid_civet_folder_inspection(tmp_path):
+    subject = tmp_path / "sub-001"
+    (subject / "native").mkdir(parents=True)
+    (subject / "final").mkdir()
+    (subject / "mask").mkdir()
+    (subject / "classify").mkdir()
+    (subject / "surfaces").mkdir()
+    (subject / "thickness").mkdir()
+    (subject / "qc").mkdir()
+    (subject / "verify").mkdir()
+    (subject / "logs").mkdir()
+
+    (subject / "native" / "sub-001_native_t1.mnc").write_text("native")
+    (subject / "final" / "sub-001_final.mnc").write_text("final")
+    (subject / "mask" / "sub-001_brain_mask.mnc").write_text("mask")
+    (subject / "classify" / "sub-001_classification.mnc").write_text("class")
+    (subject / "surfaces" / "sub-001_left_white.obj").write_text("surface")
+    (subject / "thickness" / "sub-001_thickness.txt").write_text("1 2 3")
+    (subject / "qc" / "sub-001_qc.csv").write_text("subject_id,MASK_ERROR\nsub-001,1\n")
+    (subject / "verify" / "sub-001_verify.png").write_text("png")
+    (subject / "logs" / "civet.log").write_text("log")
+
+    result = inspect_civet_folder(str(subject))
+
+    assert result["status"] == "ok"
+    assert result["n_files_scanned"] == 9
+    for group in (
+        "native_images",
+        "final_images",
+        "masks",
+        "classification_files",
+        "surfaces",
+        "thickness_files",
+        "qc_tables",
+        "verify_images",
+        "logs",
+    ):
+        assert result["groups"][group]["count"] >= 1
+
+
+def test_missing_folder_returns_error(tmp_path):
+    result = inspect_civet_folder(str(tmp_path / "missing"))
+
+    assert result["status"] == "error"
+    assert "does not exist" in result["message"]
+
+
+def test_qc_pass_case(tmp_path):
+    qc_file = tmp_path / "qc.tsv"
+    qc_file.write_text(
+        "subject_id\tMASK_ERROR\tLEFT_INTER\tRIGHT_INTER\tSURFACE_INTERSECTIONS\n"
+        "sub-001\t10\t100\t25\t500\n"
+    )
+
+    result = run_civet_qc_check(str(qc_file), subject_id="sub-001")
+
+    assert result["status"] == "ok"
+    assert result["problems"] == []
+    assert result["n_rows_checked"] == 1
+
+
+def test_qc_warning_case(tmp_path):
+    qc_file = tmp_path / "qc.txt"
+    qc_file.write_text(
+        "subject_id MASK_ERROR LEFT_INTER RIGHT_INTER SURFACE_INTERSECTIONS\n"
+        "sub-001 11 101 99 501\n"
+    )
+
+    result = run_civet_qc_check(str(qc_file), subject_id="sub-001")
+
+    assert result["status"] == "warning"
+    assert [problem["metric"] for problem in result["problems"]] == [
+        "MASK_ERROR",
+        "LEFT_INTER",
+        "SURFACE_INTERSECTIONS",
+    ]
+
+
+def test_missing_qc_file_returns_error(tmp_path):
+    result = run_civet_qc_check(str(tmp_path / "missing.csv"))
+
+    assert result["status"] == "error"
+    assert "does not exist" in result["message"]
+
+
+def test_valid_thickness_file_summary(tmp_path):
+    thickness_file = tmp_path / "thickness.txt"
+    thickness_file.write_text("1.0 2.0\n3.0 4.0\n")
+
+    result = load_cortical_thickness_map(str(thickness_file))
+
+    assert result["status"] == "ok"
+    assert result["n_vertices"] == 4
+    assert result["mean_thickness"] == 2.5
+    assert math.isclose(result["std_thickness"], 1.118033988749895)
+    assert result["min_thickness"] == 1.0
+    assert result["max_thickness"] == 4.0
+    assert result["preview_values"] == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_thickness_file_with_bad_tokens_returns_warning(tmp_path):
+    thickness_file = tmp_path / "thickness.txt"
+    thickness_file.write_text("1.0 bad -2.0 12.5 nope\n")
+
+    result = load_cortical_thickness_map(str(thickness_file))
+
+    assert result["status"] == "warning"
+    assert result["n_vertices"] == 3
+    assert result["n_skipped_tokens"] == 2
+    assert any("non-numeric" in warning for warning in result["warnings"])
+    assert any("Negative" in warning for warning in result["warnings"])
+    assert any("Unusually large" in warning for warning in result["warnings"])
+
+
+def test_missing_thickness_file_returns_error(tmp_path):
+    result = load_cortical_thickness_map(str(tmp_path / "missing.txt"))
+
+    assert result["status"] == "error"
+    assert "does not exist" in result["message"]
+
+
+def test_visualize_civet_surface_generates_html(tmp_path):
+    surface = tmp_path / "tiny.obj"
+    surface.write_text(
+        "\n".join(
+            [
+                "v 0 0 0",
+                "v 1 0 0",
+                "v 0 1 0",
+                "f 1 2 3",
+            ]
+        )
+    )
+
+    result = visualize_civet_surface(str(surface), output_dir=str(tmp_path / "outputs"))
+
+    assert result["status"] == "ok"
+    assert result["n_vertices"] == 3
+    assert result["n_faces"] == 1
+    assert result["warnings"] == []
+    assert result["figure_path"].endswith("tiny_surface.html")
+    assert (tmp_path / "outputs" / "tiny_surface.html").exists()
+
+
+def test_visualize_civet_surface_with_overlay(tmp_path):
+    surface = tmp_path / "tiny.obj"
+    surface.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n")
+    overlay = tmp_path / "overlay.txt"
+    overlay.write_text("0.1 0.2 0.3\n")
+
+    result = visualize_civet_surface(
+        str(surface),
+        overlay_path=str(overlay),
+        output_dir=str(tmp_path / "outputs"),
+    )
+
+    assert result["status"] == "ok"
+    assert result["overlay_path"] == str(overlay)
+    html = (tmp_path / "outputs" / "tiny_surface.html").read_text()
+    assert "Overlay" in html
+
+
+def test_visualize_civet_surface_overlay_length_mismatch_returns_error(tmp_path):
+    surface = tmp_path / "tiny.obj"
+    surface.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n")
+    overlay = tmp_path / "overlay.txt"
+    overlay.write_text("0.1 0.2\n")
+
+    result = visualize_civet_surface(str(surface), overlay_path=str(overlay))
+
+    assert result["status"] == "error"
+    assert "Overlay length does not match" in result["message"]
+    assert result["n_vertices"] == 3
+    assert result["n_faces"] == 1
+
+
+def test_visualize_civet_surface_parse_failure_returns_error(tmp_path):
+    surface = tmp_path / "broken.obj"
+    surface.write_text("not an obj\n")
+
+    result = visualize_civet_surface(str(surface), output_dir=str(tmp_path / "outputs"))
+
+    assert result["status"] == "error"
+    assert "Could not parse surface file" in result["message"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = mcp_server/tests


### PR DESCRIPTION
This PR adds the first CIVET skill MVP for the CyberNeuro MCP server.

Changes:
- Added CIVET folder inspection skill
- Added CIVET QC parsing and warning logic
- Added cortical thickness map loader
- Added CIVET surface visualization skill
- Added HTTP endpoints in the existing MCP server
- Added pytest coverage for CIVET skills
- Added CIVET_SKILLS.md with curl usage examples

Validation:
- python -m pytest -q passes
- MCP server startup check passes
- /api/schema includes the new CIVET endpoints
- CIVET endpoints return JSON responses