### PR TITLE
Add mapmyvisitors visitor tracking as a collapsible bottom banner

### DIFF
--- a/cyberneuro_multi-agent-neuroimaging-analysis/index.html
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/index.html
@@ -90,10 +90,12 @@
       }
       /* When collapsed, slide the panel down so only the tab remains visible */
       #visitor-map-banner.collapsed { transform: translateY(100%); }
+      /* Tab docks bottom-left to stay clear of the chat composer's Send button
+         (bottom-right of the app's right panel). */
       #visitor-map-toggle {
         position: absolute;
         top: -28px;
-        right: 16px;
+        left: 16px;
         height: 28px;
         padding: 0 12px;
         display: inline-flex;
@@ -121,9 +123,9 @@
         overflow: hidden;
       }
     </style>
-    <div id="visitor-map-banner">
+    <div id="visitor-map-banner" class="collapsed">
       <button id="visitor-map-toggle" type="button"
-              aria-controls="visitor-map-panel" aria-expanded="true"
+              aria-controls="visitor-map-panel" aria-expanded="false"
               onclick="(function(b){var c=b.classList.toggle('collapsed');this.setAttribute('aria-expanded', String(!c));}).call(this, document.getElementById('visitor-map-banner'))">
         <span>Visitor map</span>
         <span class="chev" aria-hidden="true">▾</span>

--- a/cyberneuro_multi-agent-neuroimaging-analysis/index.html
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/index.html
@@ -68,11 +68,9 @@
     <!--
       Visitor tracking widget (mapmyvisitors.com)
       -----------------------------------------------------------------
-      1. Sign in at https://mapmyvisitors.com and add this site's URL.
-      2. Copy the generated widget snippet from your dashboard.
-      3. Replace YOUR_MAPMYVISITORS_ID below with the "d=" value from
-         that snippet (it is unique to your site).
-      Renders as a collapsible banner docked to the bottom of the page.
+      Tracking ID (the "d=" param) is registered to this site on the
+      mapmyvisitors.com dashboard. Renders as a collapsible banner docked
+      to the bottom of the page, collapsed by default.
     -->
     <style>
       #visitor-map-banner {
@@ -132,7 +130,7 @@
       </button>
       <div id="visitor-map-panel">
         <script type="text/javascript" id="mapmyvisitors"
-                src="//mapmyvisitors.com/map.js?d=YOUR_MAPMYVISITORS_ID&cl=ffffff&w=a"
+                src="//mapmyvisitors.com/map.js?d=GZumtsJdo4jDnnw7HH45fJf67frmEtgjtHEhoAexSds&cl=ffffff&w=a"
                 async="async"></script>
       </div>
     </div>

--- a/cyberneuro_multi-agent-neuroimaging-analysis/index.html
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/index.html
@@ -64,5 +64,22 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
+
+    <!--
+      Visitor tracking widget (mapmyvisitors.com)
+      -----------------------------------------------------------------
+      1. Sign in at https://mapmyvisitors.com and add this site's URL.
+      2. Copy the generated widget snippet from your dashboard.
+      3. Replace YOUR_MAPMYVISITORS_ID below with the "d=" value from
+         that snippet (it is unique to your site).
+      The badge renders fixed in the bottom-right corner.
+    -->
+    <div id="visitor-map-badge"
+         style="position: fixed; bottom: 12px; right: 12px; z-index: 9999;
+                opacity: 0.85; max-width: 120px;">
+      <script type="text/javascript" id="mapmyvisitors"
+              src="//mapmyvisitors.com/map.js?d=YOUR_MAPMYVISITORS_ID&cl=ffffff&w=a"
+              async="async"></script>
+    </div>
   </body>
 </html>

--- a/cyberneuro_multi-agent-neuroimaging-analysis/index.html
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/index.html
@@ -72,14 +72,67 @@
       2. Copy the generated widget snippet from your dashboard.
       3. Replace YOUR_MAPMYVISITORS_ID below with the "d=" value from
          that snippet (it is unique to your site).
-      The badge renders fixed in the bottom-right corner.
+      Renders as a collapsible banner docked to the bottom of the page.
     -->
-    <div id="visitor-map-badge"
-         style="position: fixed; bottom: 12px; right: 12px; z-index: 9999;
-                opacity: 0.85; max-width: 120px;">
-      <script type="text/javascript" id="mapmyvisitors"
-              src="//mapmyvisitors.com/map.js?d=YOUR_MAPMYVISITORS_ID&cl=ffffff&w=a"
-              async="async"></script>
+    <style>
+      #visitor-map-banner {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 9999;
+        background: rgba(15, 23, 42, 0.92);
+        border-top: 1px solid #334155;
+        backdrop-filter: blur(6px);
+        font-family: 'Inter', sans-serif;
+        transform: translateY(0);
+        transition: transform 0.3s ease;
+      }
+      /* When collapsed, slide the panel down so only the tab remains visible */
+      #visitor-map-banner.collapsed { transform: translateY(100%); }
+      #visitor-map-toggle {
+        position: absolute;
+        top: -28px;
+        right: 16px;
+        height: 28px;
+        padding: 0 12px;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: rgba(15, 23, 42, 0.92);
+        border: 1px solid #334155;
+        border-bottom: none;
+        border-radius: 8px 8px 0 0;
+        color: #e2e8f0;
+        font-size: 12px;
+        font-weight: 500;
+        cursor: pointer;
+        line-height: 1;
+      }
+      #visitor-map-toggle:hover { background: rgba(30, 41, 59, 0.95); }
+      #visitor-map-toggle .chev { transition: transform 0.3s ease; }
+      #visitor-map-banner.collapsed #visitor-map-toggle .chev { transform: rotate(180deg); }
+      #visitor-map-panel {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 10px 16px;
+        max-height: 220px;
+        overflow: hidden;
+      }
+    </style>
+    <div id="visitor-map-banner">
+      <button id="visitor-map-toggle" type="button"
+              aria-controls="visitor-map-panel" aria-expanded="true"
+              onclick="(function(b){var c=b.classList.toggle('collapsed');this.setAttribute('aria-expanded', String(!c));}).call(this, document.getElementById('visitor-map-banner'))">
+        <span>Visitor map</span>
+        <span class="chev" aria-hidden="true">▾</span>
+      </button>
+      <div id="visitor-map-panel">
+        <script type="text/javascript" id="mapmyvisitors"
+                src="//mapmyvisitors.com/map.js?d=YOUR_MAPMYVISITORS_ID&cl=ffffff&w=a"
+                async="async"></script>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a visitor-tracking widget from [mapmyvisitors.com](https://mapmyvisitors.com/) to the frontend (`cyberneuro_multi-agent-neuroimaging-analysis/index.html`), rendered as a collapsible banner docked to the bottom of the page.

- **Collapsed by default** — on load, only a small "Visitor map" tab appears in the bottom-left corner; the split-panel layout, chat composer, and Send button stay fully clear.
- Clicking the tab slides the map panel up along the bottom edge; clicking again tucks it away (`aria-expanded` is kept in sync).
- Lives outside `#root`, so React never touches it; styled to match the dark slate theme.
- Wired with the site's registered tracking ID (`d=GZumtsJd…`).

## Verification

- Ran the exact CI build (`npm ci && npm run build:gh-pages`): builds cleanly, and the banner markup, styles, and tracking script survive the Vite HTML transform intact in `dist/index.html` (external `//mapmyvisitors.com` URL correctly left un-rewritten by the base path).
- Served the built `dist/` at the `/brain-network-chart/` base path and drove it headless: React app boots, banner defaults to collapsed, toggle expands/collapses with correct aria state.
- Deploy workflow (`deploy-pages.yml`) triggers on pushes to `gh-page` touching `cyberneuro_multi-agent-neuroimaging-analysis/**`, which this change matches.

Note: the map itself couldn't be rendered in the sandbox (network policy blocks mapmyvisitors.com), so after deploy, confirm the map appears in the expanded banner and that visits register on the mapmyvisitors dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsjn2FbTSeynG5ZPQQJbjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wsjn2FbTSeynG5ZPQQJbjv)_