### PR TITLE
Fix visitor map rendering viewport-wide instead of inside its panel

### DIFF
--- a/cyberneuro_multi-agent-neuroimaging-analysis/index.html
+++ b/cyberneuro_multi-agent-neuroimaging-analysis/index.html
@@ -120,6 +120,23 @@
         max-height: 220px;
         overflow: hidden;
       }
+      /* The map.js widget sizes itself to its parent's width (w=a means
+         adaptive), so it must live in a fixed-width box — otherwise it
+         renders a viewport-wide map. Also hard-cap anything it injects. */
+      #visitor-map-widget-box {
+        width: 320px;
+        max-width: 90vw;
+        max-height: 200px;
+        overflow: hidden;
+      }
+      #visitor-map-widget-box div,
+      #visitor-map-widget-box a,
+      #visitor-map-widget-box img,
+      #visitor-map-widget-box canvas,
+      #visitor-map-widget-box iframe {
+        max-width: 100% !important;
+        max-height: 200px !important;
+      }
     </style>
     <div id="visitor-map-banner" class="collapsed">
       <button id="visitor-map-toggle" type="button"
@@ -129,9 +146,12 @@
         <span class="chev" aria-hidden="true">▾</span>
       </button>
       <div id="visitor-map-panel">
-        <script type="text/javascript" id="mapmyvisitors"
-                src="//mapmyvisitors.com/map.js?d=GZumtsJdo4jDnnw7HH45fJf67frmEtgjtHEhoAexSds&cl=ffffff&w=a"
-                async="async"></script>
+        <!-- Official snippet verbatim (no async: map.js relies on finding
+             its own script tag at parse time to place the widget). -->
+        <div id="visitor-map-widget-box">
+          <script type="text/javascript" id="mapmyvisitors"
+                  src="//mapmyvisitors.com/map.js?d=GZumtsJdo4jDnnw7HH45fJf67frmEtgjtHEhoAexSds&cl=ffffff&w=a"></script>
+        </div>
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Summary

Fixes the bug from #16 where the visitor map rendered as a huge viewport-wide map flooding the bottom of the page instead of staying inside the collapsible banner.

**Root cause:** `map.js` with `w=a` (adaptive width) sizes the widget to its **parent container's width**. The panel spanned the full viewport, so the widget rendered a viewport-wide map. The added `async` attribute (not part of the official snippet) also interfered with the script's parse-time self-location.

**Fix:**
- Wrap the widget script in a fixed `320px` box (`#visitor-map-widget-box`) so the adaptive sizing produces a ~320×160 map
- Use the official snippet verbatim (no `async`)
- Hard-cap (`max-width`/`max-height`) any elements the script injects, as a backstop, with `overflow: hidden` on both the box and the panel

## Verification

- Rebuilt with the exact CI command (`npm run build:gh-pages`); markup survives the Vite transform
- Served the built `dist/` at `/brain-network-chart/` and drove it headless, simulating the widget's injection behavior:
  - Widget box measures **320px** — that's what `w=a` will adapt to
  - Worst case (injected 1400×700 element): banner stays clamped to **221px**, nothing escapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsjn2FbTSeynG5ZPQQJbjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wsjn2FbTSeynG5ZPQQJbjv)_